### PR TITLE
fix: linter timeout on CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,8 @@ jobs:
         run: make fmt-check
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
+        with:
+          args: --timeout 3m
       - name: Run unit tests
         run: make test
       - name: Build the application


### PR DESCRIPTION
increasing timeout for golangci-lint due to random CI failures :
```bash
  Running [/home/runner/golangci-lint-1.50.1-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  level=error msg="Running error: context loading failed: failed to load packages: timed out to load packages: context deadline exceeded"
  level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
```